### PR TITLE
Fix Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,13 +178,13 @@
                 </configuration>
             </plugin>
             <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
-				<configuration>
-					<failOnMissingWebXml>false</failOnMissingWebXml>
-				</configuration>
-			</plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.1.1</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The Maven build failed due to a missing web.xml. Changed the web.xml so that Maven ignores the "web.xml missing error". Verified behaviour with Tomcat 7.

Note: Trailing whitespaces were removed in the other lines.
