### PR TITLE
Use proxrox to define proxy strategy

### DIFF
--- a/.proxrox.yaml
+++ b/.proxrox.yaml
@@ -1,0 +1,7 @@
+serverName: 'moviedatabase.com'
+root: false
+port: 80
+proxy:
+  '/': 'http://localhost:8080/movie-app/'
+  '/movie-app/': 'http://localhost:8080/movie-app/'
+  '/actor-app/': 'http://localhost:8082/actor-app/'


### PR DESCRIPTION
The movie database currently relies on manual nginx configuration. This
means that developers need to copy the nginx config to system
directories and also keep them in sync with the files from the
repositories.

Additionally, the config file does not include instructions for GZip
and logs which come in handy during development.

Proxrox is a viable alternative to manual nginx configuration as it
has support for automatic nginx installation (for OS X) and a config
file format that can be shared via the repository.

Unfortunately not all of Proxrox's features can be used as the paths
in the `*.properties` files require:
1. Port 80
2. HTTP

It would be nice to remove this restriction and therefore enable the usage
of alternative protocols (https, SPDY) and ports that can be used without super
user privileges.

This pull request does not include necessary documentation (`README.md`)
changes as I want to use this pull request as a base for discussion first :).
