### PR TITLE
share source code between host and virtual machine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /.settings/
 /.project
+/logs/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
     # config.vm.network "forwarded_port", guest: 80, host: 8080
 
     config.vm.network "private_network", ip: "192.168.56.13"
-    config.vm.synced_folder "share", "/home/vagrant/share", create: true
+    config.vm.synced_folder ".", "/home/vagrant/share", create: true
     config.vm.synced_folder "logs", "/opt/moviedatabase/logs", create: true
 
     config.vm.provider "virtualbox" do |vb|

--- a/init.sh
+++ b/init.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-MOVIE_DATABASE_HOME=/home/vagrant/share/movie-database
+MOVIE_DATABASE_HOME=/home/vagrant/share
 
 apt-get -y update
 apt-get -y install \
     unzip \
-    git \
     redis-server \
     nginx \
     openjdk-7-jdk \
@@ -15,11 +14,6 @@ apt-get -y install \
 # /usr/bin/node is required by bower
 if [ ! -e /usr/bin/node ]; then
     ln -s /usr/bin/{nodejs,node}
-fi
-
-# clone project form github
-if [ ! -e $MOVIE_DATABASE_HOME ]; then
-    git clone https://github.com/tobiasflohre/movie-database.git $MOVIE_DATABASE_HOME
 fi
 
 cd $MOVIE_DATABASE_HOME

--- a/movie-database-vagrant/.gitignore
+++ b/movie-database-vagrant/.gitignore
@@ -1,4 +1,0 @@
-/share/
-/logs/
-/.vagrant/
-.DS_Store


### PR DESCRIPTION
Hi Tobias,

thx for adding vagrant support to your project. I would like to propose one more change. Right now you end up having two versions of the source code. One you checked out from github and the other which is checked out by `init.sh` while provisioning the virtual machine.

i have removed the `git clone [...]` command from `init.sh` and changed the `share/` to point to the source code you already checked out from github. This way you can work with the source code in your IDE and having changes take effect in the virtual machine as well.

There is a catch although. `Vagrantfile` and `init.sh` are now located in the root of your project. And you will get changes in `application.properties` when using vagrant. Those changes come from `init.sh` replacing IP address of redis server while provisioning. I can live with it. if you can too feel free to accept the pull request ;)

regards,
eugen